### PR TITLE
아이템 흐르는 방향 변경 속도 및 예외 처리 추가

### DIFF
--- a/Assets/Script/Scraps/Scrap.cs
+++ b/Assets/Script/Scraps/Scrap.cs
@@ -15,8 +15,6 @@ public class Scrap : MonoBehaviour
     private bool _isHited = false;
     private Rigidbody _scrapRigidBody;
 
-    private float _velocityChangeTime = 10f;
-    private float _currentChangeTime = 0f;
     private Vector3 _refVector3 = Vector3.zero;
     public void F_SettingScrap()
     {
@@ -66,12 +64,12 @@ public class Scrap : MonoBehaviour
         }
     }
 
-    public IEnumerator C_ItemVelocityChange(Vector3 v_newVelocity)
+    public IEnumerator C_ItemVelocityChange(Vector3 v_newVelocity, float v_changeSpeed)
     {
         while (_scrapRigidBody.velocity != v_newVelocity)
         {
             _scrapRigidBody.velocity
-                    = Vector3.SmoothDamp(_scrapRigidBody.velocity, v_newVelocity, ref _refVector3, 7f).normalized * ScrapManager.Instance._item_MoveSpeed;
+                    = Vector3.SmoothDamp(_scrapRigidBody.velocity, v_newVelocity, ref _refVector3, v_changeSpeed).normalized * ScrapManager.Instance._item_MoveSpeed;
             yield return new WaitForSeconds(Time.deltaTime);
         }
     }


### PR DESCRIPTION
1. 아이템 최초 흐르는 방향 설정 잘못 설정돼있던 것 수정
2. 방향 변경 시 (직각, 둔각, 예각) 각도마다 아이템 흐름의 변경 속도 다르게 설정