### PR TITLE
씬 전환 시 매니저들 삭제 기능 추가

### DIFF
--- a/Assets/Scenes/00_Lobby.unity
+++ b/Assets/Scenes/00_Lobby.unity
@@ -4310,7 +4310,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 876423709}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b00f9a1a454a4e944a151b8685096887, type: 3}
+  m_Script: {fileID: 11500000, guid: b2e8111aaaa5c7944a073537425d06c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _planet: {fileID: 1467485415}

--- a/Assets/Script/Lobby/EarthManager.cs
+++ b/Assets/Script/Lobby/EarthManager.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class EarthManager : MonoBehaviour
 {
@@ -18,6 +20,18 @@ public class EarthManager : MonoBehaviour
     {
         F_PlanetMove();
         F_PeopleMove();
+        // 1. Managers 이름을 가진 오브젝트가 있는지 확인.
+        // 2. 있으면 그냥 없애버리기.
+        F_DestroyManagers();
+    }
+
+    private void F_DestroyManagers()
+    {
+        GameObject _manager = GameObject.Find("Managers");
+        if (_manager != null)
+            Destroy(_manager);
+        else
+            return;
     }
 
     private void  F_PlanetMove()


### PR DESCRIPTION
1. 산소 부족으로 사망 시 로비 씬으로 돌아가는 데, 그 전에 있던 매니저들 삭제 기능 추가 (임시)